### PR TITLE
Port to youtube-dl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 old/**
 
 .env
+xp3-venv

--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ One of the base assumptions is that the name of the file is in the following for
 git clone https://github.com/Assaf-Alon/XP3
 ```
 
+You also need to manually install youtube-dl, by packaging and installing it:
+```
+pip install --upgrade setuptools wheel
+git clone https://github.com/ytdl-org/youtube-dl.git
+cd youtube-dl
+python setup.py bdist_wheel
+pip install dist/youtube_dl-*.whl
+```
+
+And install [ffmpeg](https://en.wikipedia.org/wiki/FFmpeg)
+```
+sudo apt-get install ffmpeg
+```
+
 ### Updating metadata for a single file
 ```python
 from mp3_metadata import update_metadata_for_file

--- a/README.md
+++ b/README.md
@@ -13,15 +13,6 @@ One of the base assumptions is that the name of the file is in the following for
 git clone https://github.com/Assaf-Alon/XP3
 ```
 
-You also need to manually install youtube-dl, by packaging and installing it:
-```
-pip install --upgrade setuptools wheel
-git clone https://github.com/ytdl-org/youtube-dl.git
-cd youtube-dl
-python setup.py bdist_wheel
-pip install dist/youtube_dl-*.whl
-```
-
 And install [ffmpeg](https://en.wikipedia.org/wiki/FFmpeg)
 #### Windows
 1. [Download ffmpeg](https://www.ffmpeg.org/download.html)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ pip install dist/youtube_dl-*.whl
 ```
 
 And install [ffmpeg](https://en.wikipedia.org/wiki/FFmpeg)
+#### Windows
+1. [Download ffmpeg](https://www.ffmpeg.org/download.html)
+2. Extract content in `C:\ffmpeg`, and add to the Path environment variable the following path: `C:\ffmpeg\bin`
+
+#### Ubuntu
 ```
 sudo apt-get install ffmpeg
 ```

--- a/mp3_download.py
+++ b/mp3_download.py
@@ -4,7 +4,7 @@ import logging
 from os.path import join
 from typing import List, Optional, Tuple
 
-import youtube_dl
+import yt_dlp as youtube_dl
 
 from config import DEFAULT_PLAYLIST, IS_DEBUG, MP3_DIR
 from mp3_metadata import MP3MetaData

--- a/mp3_download.py
+++ b/mp3_download.py
@@ -1,12 +1,12 @@
 """Functions used to get data related to mp3 files and download them"""
+
 import logging
-from os.path import basename, join
+from os.path import join
 from typing import List, Optional, Tuple
 
-import pytube
-from moviepy.editor import VideoFileClip
+import youtube_dl
 
-from config import DEFAULT_PLAYLIST, IS_DEBUG, MP3_DIR, MP4_DIR
+from config import DEFAULT_PLAYLIST, IS_DEBUG, MP3_DIR
 from mp3_metadata import MP3MetaData
 
 logging.basicConfig()
@@ -35,95 +35,73 @@ def get_playlist_songs(
     Returns:
         List[Tuple[MP3MetaData, str]]: List of tuples - metadata regarding the song, and the song's URL.
     """
-    playlist = pytube.Playlist(playlist_url)
+    ydl_opts = {
+        "quiet": True,
+        "extract_flat": True,
+        "skip_download": True,
+    }
+    with youtube_dl.YoutubeDL(ydl_opts) as ydl:
+        playlist_dict = ydl.extract_info(playlist_url, download=False)
 
-    logger.debug("Number of videos in playlist: %d", len(playlist.video_urls))
+    logger.debug("Number of videos in playlist: %d", len(playlist_dict["entries"]))
     start_index -= 1
-    end_index = min(end_index, len(playlist.video_urls)) - 1
-    logger.debug("Start: %s, End: %s", start_index, end_index)
+    end_index = min(end_index, len(playlist_dict["entries"])) - 1
+    logger.debug("Start: %d, End: %d", start_index, end_index)
 
     songs = []
-    videos = list(playlist.videos)
     for index in range(start_index, end_index + 1):
-        py_video = videos[index]
-        metadata = MP3MetaData.from_video(title=py_video.title, channel=py_video.author, interactive=interactive)
+        logger.debug(" > Processing song (%d/%d)", index, end_index)
+        entry = playlist_dict["entries"][index]
+        metadata = MP3MetaData.from_video(title=entry["title"], channel=entry["uploader"], interactive=interactive)
         if update_album:
             metadata.update_missing_fields(interactive=interactive)
             metadata.update_album_art()
-        songs.append((metadata, py_video.watch_url))
+        songs.append((metadata, entry["url"]))
 
     return songs
 
 
-def download_ytvid(video_url: str, out_path: str = MP4_DIR, title: Optional[str] = None) -> Optional[str]:
-    """Downloads a video from YouTube
-
-    Args:
-        video_url (str): The URL of the video
-        out_path (str, optional): Base path of the downloaded video. Defaults to MP4_DIR.
-        title (Optional[str], optional): File name of the downloaded video. If None, uses video title. Defaults to None.
-
-    Returns:
-        Optional[str]: Path to saved video if succeeded
-    """
-    if title and not title.endswith(".mp4"):
-        title = title + ".mp4"
-    mp4_stream = pytube.YouTube(video_url).streams.filter(file_extension="mp4").first()
-    if not mp4_stream:
-        logger.error("No stream found for %s", video_url)
-        return None
-    return mp4_stream.download(output_path=out_path, filename=title)
-
-
-def convert_mp4_to_mp3(mp4_path: str) -> Optional[str]:
-    """Converts an mp4 file to an mp3 file.
-
-    Args:
-        mp4_path (str): Path to the input mp4 file.
-
-    Returns:
-        Optional[str]: Path to the output mp3 file.
-    """
-    assert mp4_path.endswith(".mp4")
-    mp4_filename = basename(mp4_path)
-    mp3_path = join(MP3_DIR, mp4_filename[:-1] + "3")
-    video = VideoFileClip(mp4_path)
-    if not video.audio:
-        logger.error("Audio not found for %s", mp4_path)
-        return None
-    video.audio.write_audiofile(mp3_path)
-    return mp3_path
-
-
 def download_song(
     song_url: str,
+    out_path: str = MP3_DIR,
+    title: Optional[str] = None,  # TODO - Get MP3MetaData instead
     update_album: bool = True,
     interactive: bool = True,
-):
+) -> Optional[str]:
     """Downloads a single song and updates its metadata
 
     Args:
         song_url (str): The URL of the song
+        out_path (str, optional): The directory to save the downloaded song. Defaults to MP3_DIR.
+        title (str, optional): The title of the song. Defaults to None.
         update_album (bool, optional): Whether to update album metadata or not. Defaults to True.
         interactive (bool, optional): Whether to run metadata updates in interactive mode. Defaults to True.
+
+    Returns:
+        Optional[str]: Path to the downloaded mp3 file.
     """
-    py_video = pytube.YouTube(song_url)
-    metadata = MP3MetaData.from_video(title=py_video.title, channel=py_video.author, interactive=interactive)
+    ydl_opts = {
+        "format": "bestaudio/best",
+        "outtmpl": join(out_path, f"{title}.%(ext)s") if title else join(out_path, "%(title)s.%(ext)s"),
+        "quiet": True,
+        "postprocessors": [
+            {
+                "key": "FFmpegExtractAudio",
+                "preferredcodec": "mp3",
+                "preferredquality": "192",
+            }
+        ],
+    }
+    with youtube_dl.YoutubeDL(ydl_opts) as ydl:
+        info_dict = ydl.extract_info(song_url, download=True)
+    mp3_path = join(out_path, f"{title}.mp3") if title else join(out_path, f"{info_dict['title']}.mp3")
+    metadata = MP3MetaData.from_video(title=info_dict["title"], channel=info_dict["uploader"], interactive=interactive)
     if update_album:
         metadata.update_missing_fields(interactive=interactive)
         metadata.update_album_art()
-    logger.debug(" > Downloading %s, from %s", metadata.title, song_url)
-    filename = download_ytvid(song_url, out_path=MP4_DIR, title=metadata.title)
-    if not filename:
-        return
-
-    logger.debug(" >> Downloaded %s", filename)
-    mp3_path = convert_mp4_to_mp3(mp4_path=filename)
-    if not mp3_path:
-        return
-
     metadata.apply_on_file(mp3_path)
     logger.debug(" >> Updated metadata for %s", mp3_path)
+    return mp3_path
 
 
 def download_xprimental(
@@ -146,14 +124,4 @@ def download_xprimental(
     )
     for metadata, url in songs:
         logger.debug(" > Downloading %s, from %s", metadata.title, url)
-        filename = download_ytvid(url, out_path=MP4_DIR, title=metadata.title)
-        if not filename:
-            continue
-
-        logger.debug(" >> Downloaded %s", filename)
-        mp3_path = convert_mp4_to_mp3(mp4_path=filename)
-        if not mp3_path:
-            continue
-
-        metadata.apply_on_file(mp3_path)
-        logger.debug(" >> Updated metadata for %s", mp3_path)
+        download_song(url, out_path=MP3_DIR, title=metadata.title, update_album=True, interactive=interactive)

--- a/mp3_metadata.py
+++ b/mp3_metadata.py
@@ -428,13 +428,13 @@ class MP3MetaData:  # pylint: disable=E0102
             self.band = recording.artist
             self.song = recording.title
 
-    def update_missing_fields(self, interactive: bool = False, keep_current_metadata: bool = False):
+    def update_missing_fields(self, interactive: bool = False, keep_current_metadata: bool = True):
         """Updates missing mp3 metadata fields.
         Args:
             interactive (bool, optional): Should run in interactive mode, get user feedback regarding title fixes.
                                           Defaults to False.
             keep_current_metadata (bool, optional): States whether to use existing metadata.
-                                                    Defaults to False.
+                                                    Defaults to True.
         """
         if not self.title:
             logger.debug("No title. Returning...")

--- a/mp3_metadata.py
+++ b/mp3_metadata.py
@@ -276,7 +276,7 @@ def get_suggested_recording(recordings: List[ReleaseRecording], partial_metadata
     return suggested_recording_index if suggested_recording_index >= 0 else potential_single_index
 
 
-class MP3MetaData:  # pylint: disable=E0102
+class MP3MetaData:  # pylint: disable=E0102,R0917
     """Class that represents mp3 metadata."""
 
     def __init__(
@@ -627,7 +627,7 @@ Skip?""",
 # TODO - use this to load metadata if exists, and process song name (DECO)
 
 
-def update_metadata_for_directory(
+def update_metadata_for_directory(  # pylint: disable=R0917
     base_path: str,
     interactive: bool = True,
     update_album_art: bool = False,

--- a/mp3_metadata.py
+++ b/mp3_metadata.py
@@ -571,7 +571,9 @@ Skip?""",
             return
 
         # For linter
-        assert isinstance(mp3_file, music_tag.id3.Mp3File)
+        assert isinstance(mp3_file, music_tag.id3.Mp3File), "Expected music_tag.id3.Mp3File file, actually got" + str(
+            type(mp3_file)
+        )
 
         if self.song:
             mp3_file["title"] = self.song

--- a/music_api.py
+++ b/music_api.py
@@ -28,7 +28,7 @@ def _clean_title(title: str) -> str:
 class ReleaseRecording:
     """Class that represents a recording in MusicBrainz"""
 
-    def __init__(
+    def __init__(  # pylint: disable=R0917
         self,
         album: str,
         year: int,

--- a/music_api.py
+++ b/music_api.py
@@ -92,10 +92,12 @@ def get_album_candidates(json_data: Any, artist: str, title: str) -> List[Releas
             altered_received_title = _clean_title(received_title)
             altered_title = _clean_title(title)
 
+            # TODO - check if strings are closes instead
             if altered_received_title != altered_title:
                 logger.debug("Skipping because of title mismatch (%s != %s)", altered_title, altered_received_title)
                 continue
 
+            # TODO - check if strings are closes instead
             if received_artist.lower() != artist.lower():
                 logger.debug("Skipping because of artist mismatch (%s != %s)", artist, received_artist)
                 continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ music_tag==0.4.3
 python-decouple==3.8
 colorama==0.4.5
 python-dateutil==2.8.2
-youtube-dl
+yt-dlp==2025.1.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 requests==2.32.0
-pytube==15.0.0
 moviepy==1.0.3
 music_tag==0.4.3
 python-decouple==3.8
 colorama==0.4.5
 python-dateutil==2.8.2
+youtube-dl

--- a/tests/test_download_song.py
+++ b/tests/test_download_song.py
@@ -1,10 +1,8 @@
 """Tests functions related to songs downloading """
-import hashlib
-import os
+
 import unittest
 
-from config import TMP_DIR
-from mp3_download import download_ytvid, get_playlist_songs
+from mp3_download import get_playlist_songs
 
 
 class TestDownloadSong(unittest.TestCase):
@@ -78,26 +76,4 @@ class TestDownloadSong(unittest.TestCase):
         self.assertEqual(song.year, 2016)
         self.assertEqual(song.track, 5)
 
-    @unittest.skip("Heavy test")
-    def test_download_ytvid1(self):
-        """Tests the download_ytvid function"""
-        playlist_url = "https://www.youtube.com/playlist?list=PLGN96WAC2Fv2DNdIbAHQsGVO3IxNawtu4"
-
-        songs = get_playlist_songs(
-            playlist_url=playlist_url,
-            start_index=1,
-            end_index=1,
-            interactive=False,
-        )
-
-        song, url = songs[0]
-
-        download_ytvid(url, out_path=TMP_DIR, title=song.title)
-        song_path = os.path.join(TMP_DIR, song.title) + ".mp4"
-
-        with open(song_path, "rb") as song_file:
-            data = song_file.read()
-            song_md5 = hashlib.md5(data, usedforsecurity=False).hexdigest()
-        self.assertEqual(song_md5, "b788d8de3365ea1789b42e5fcd4a7782")
-
-        os.remove(song_path)
+    # TODO - Test actual download song function

--- a/tests/test_download_song.py
+++ b/tests/test_download_song.py
@@ -21,7 +21,7 @@ class TestDownloadSong(unittest.TestCase):
         self.assertEqual(len(songs), 1)
         song, url = songs[0]
 
-        self.assertEqual(url, "https://youtube.com/watch?v=2f_0HSWLDLg")
+        self.assertIn(url, ["https://youtube.com/watch?v=2f_0HSWLDLg", "https://www.youtube.com/watch?v=2f_0HSWLDLg"])
         self.assertEqual(song.song, "The Stage")
         self.assertEqual(song.band, "Avenged Sevenfold")
         self.assertEqual(song.title, "Avenged Sevenfold - The Stage")
@@ -41,7 +41,7 @@ class TestDownloadSong(unittest.TestCase):
         self.assertEqual(len(songs), 1)
         song, url = songs[0]
 
-        self.assertEqual(url, "https://youtube.com/watch?v=OD819p2fM1c")
+        self.assertIn(url, ["https://youtube.com/watch?v=OD819p2fM1c", "https://www.youtube.com/watch?v=OD819p2fM1c"])
         self.assertEqual(song.song, "Paradigm")
         self.assertEqual(song.band, "Avenged Sevenfold")
         self.assertEqual(song.title, "Avenged Sevenfold - Paradigm")


### PR DESCRIPTION
# Port to youtube-dl
- Moved from `pytube` to `youtube-dl`
- Moved from `youtube-dl` to `yt-dlp` because of issues with Windows, and general difficulty in package installation
- Alignment of code
- Update tests